### PR TITLE
Add `original request` field to AliceRequest and merge #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+Pipfile*

--- a/aioalice/dispatcher/webhook.py
+++ b/aioalice/dispatcher/webhook.py
@@ -56,7 +56,7 @@ class WebhookRequestHandler(web.View):
         """
         data = await self.request.json()
         try:
-            return AliceRequest(**data)
+            return AliceRequest(self.request, **data)
         except Exception:
             log.exception('Exception loading AliceRequest from\n%r', data)
             raise

--- a/aioalice/types/alice_request.py
+++ b/aioalice/types/alice_request.py
@@ -1,4 +1,5 @@
 from attr import attrs, attrib
+from aiohttp.web import Request as WebRequest
 from aioalice.utils import ensure_cls
 from . import AliceObject, Meta, Session, \
     Card, Request, Response, AliceResponse
@@ -7,7 +8,7 @@ from . import AliceObject, Meta, Session, \
 @attrs
 class AliceRequest(AliceObject):
     """AliceRequest is a request from Alice API"""
-
+    original_request = attrib(type=WebRequest)
     meta = attrib(convert=ensure_cls(Meta))
     request = attrib(convert=ensure_cls(Request))
     session = attrib(convert=ensure_cls(Session))

--- a/aioalice/types/entity.py
+++ b/aioalice/types/entity.py
@@ -3,7 +3,7 @@ from attr import attrs, attrib
 
 from aioalice.utils import ensure_cls
 from aioalice.utils.helper import Helper, HelperMode, Item
-from . import AliceObject, EntityToken, EntityValue
+from . import AliceObject, EntityTokens, EntityValue
 
 log = logging.getLogger(__name__)
 
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 class Entity(AliceObject):
     """Entity object"""
     type = attrib(type=str)
-    tokens = attrib(convert=ensure_cls(EntityToken))
+    tokens = attrib(convert=ensure_cls(EntityTokens))
     value = attrib(convert=ensure_cls(EntityValue))
 
     @type.validator

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -59,9 +59,6 @@ class TestAliceTypes(unittest.TestCase):
         self._test_entity_tokens(et, ENTITY_TOKEN)
 
     def _test_entity_value(self, ev, dct):
-        if not isinstance(dct, dict):
-            #self.assertEqual(ev, dct)
-            return
         for key in (
             'first_name',
             'patronymic_name',

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -53,25 +53,28 @@ class TestAliceTypes(unittest.TestCase):
         self._test_entity_tokens(et, ENTITY_TOKEN)
 
     def _test_entity_value(self, ev, dct):
+        if not isinstance(dct, dict):
+            #self.assertEqual(ev, dct)
+            return
         for key in (
-            'first_name',
-            'patronymic_name',
-            'last_name',
-            'country',
-            'city',
-            'street',
-            'house_number',
-            'airport',
-            'year',
-            'year_is_relative',
-            'month',
-            'month_is_relative',
-            'day',
-            'day_is_relative',
-            'hour',
-            'hour_is_relative',
-            'minute',
-            'minute_is_relative',
+                'first_name',
+                'patronymic_name',
+                'last_name',
+                'country',
+                'city',
+                'street',
+                'house_number',
+                'airport',
+                'year',
+                'year_is_relative',
+                'month',
+                'month_is_relative',
+                'day',
+                'day_is_relative',
+                'hour',
+                'hour_is_relative',
+                'minute',
+                'minute_is_relative',
                 'value',):
             if key in dct:
                 print('\nKey occured', key, '\n')
@@ -184,7 +187,7 @@ class TestAliceTypes(unittest.TestCase):
         self._test_meta(arq.meta, dct['meta'])
 
     def _test_alice_request_from_dct(self, dct):
-        alice_request = types.AliceRequest(**dct)
+        alice_request = types.AliceRequest(None, **dct)
         self._test_alice_request(alice_request, dct)
 
     def test_alice_request(self):
@@ -204,7 +207,7 @@ class TestAliceTypes(unittest.TestCase):
         self._test_alice_response(alice_response, ALICE_RESPONSE_WITH_BUTTONS)
 
     def test_response_from_request(self):
-        alice_request = types.AliceRequest(**ALICE_REQUEST)
+        alice_request = types.AliceRequest(None, **ALICE_REQUEST)
 
         alice_response = alice_request.response(
             EXPECTED_RESPONSE['response']['text']
@@ -212,7 +215,7 @@ class TestAliceTypes(unittest.TestCase):
         self._assert_payload(alice_response, EXPECTED_RESPONSE)
 
     def test_response_from_request2(self):
-        alice_request = types.AliceRequest(**ALICE_REQUEST)
+        alice_request = types.AliceRequest(None, **ALICE_REQUEST)
         alice_response = alice_request.response(
             RESPONSE_TEXT, tts=TTS,
             buttons=[types.Button(BUTTON_TEXT, url=URL)]
@@ -220,7 +223,7 @@ class TestAliceTypes(unittest.TestCase):
         self._assert_payload(alice_response, EXPECTED_RESPONSE_WITH_BUTTONS)
 
     def test_response_big_image_from_request(self):
-        alice_request = types.AliceRequest(**ALICE_REQUEST)
+        alice_request = types.AliceRequest(None, **ALICE_REQUEST)
         alice_response = alice_request.response_big_image(
             RESPONSE_TEXT, IMAGE_ID, CARD_TITLE, CARD_DESCR,
             types.MediaButton(BUTTON_TEXT, URL, MB_PAYLOAD),
@@ -229,7 +232,7 @@ class TestAliceTypes(unittest.TestCase):
         self._assert_payload(alice_response, EXPECTED_ALICE_RESPONSE_BIG_IMAGE_WITH_BUTTON)
 
     def test_response_items_list_from_request(self):
-        alice_request = types.AliceRequest(**ALICE_REQUEST)
+        alice_request = types.AliceRequest(None, **ALICE_REQUEST)
         alice_response = alice_request.response_items_list(
             RESPONSE_TEXT, CARD_HEADER_TEXT,
             [types.Image(**IMAGE)],


### PR DESCRIPTION
Add `original_request` field to AliceRequest and merge #1

This also *fixes?* the tests.

The rationale behind adding an `original_request` is this: sometimes we want to access `app` (and some info from original request) from request. As of now we don't have any means of getting app instance from request handler.