### PR TITLE
TypeError: __init__() got an unexpected keyword argument 'account_linking'

### DIFF
--- a/aioalice/types/interfaces.py
+++ b/aioalice/types/interfaces.py
@@ -5,4 +5,6 @@ from . import AliceObject
 @attrs
 class Interfaces(AliceObject):
     """Interfaces object"""
+    account_linking = attrib(factory=dict)
+    payments = attrib(factory=dict)
     screen = attrib(factory=dict)


### PR DESCRIPTION
В `meta.interfaces` появились два новых свойства, навык стал падать с ошибкой `TypeError: __init__() got an unexpected keyword argument 'account_linking'`. Правильнее было бы игнорировать неизвестные свойства.